### PR TITLE
Update publish permalink to allow for filtering

### DIFF
--- a/includes/webhook.php
+++ b/includes/webhook.php
@@ -143,7 +143,7 @@ function handlePublish($payload) {
     // WPEngine (which caches outside of WP) also listens for this action.
     clean_post_cache($post_ID);
 
-    $permalink = \Storychief\Tools\getPermalink($post_ID);
+    $permalink = apply_filters( 'storychief_publish_permalink', \Storychief\Tools\getPermalink($post_ID), $post_ID );
 
     return array(
         'id'        => $post_ID,
@@ -220,7 +220,7 @@ function handleUpdate($payload) {
     // WPEngine (which caches outside of WP) also listens for this action.
     clean_post_cache($post_ID);
 
-    $permalink = \Storychief\Tools\getPermalink($post_ID);
+    $permalink = apply_filters( 'storychief_publish_permalink', \Storychief\Tools\getPermalink($post_ID), $post_ID );
 
     return array(
         'id'        => $post_ID,


### PR DESCRIPTION
This commit adds a filter to the publish and update permalink that is returned.

Use case: publishing from StoryChief to a staging site, but the final URL will be different (such as a headless or Jamstack WordPress site):

- Staging site URL: staging.breadandjam.com/a-new-post
- Live site URL: breadandjam.com/a-new-post

In this example, the WordPress site is the staging site, but the final URL will be on the Live domain.

This addition of `apply_filters` does not change any current functionality, and allows developers to easily filter the final sent back to the StoryChief app.

I'm happy to change the hook names or receive any feedback.

Thanks for your consideration. 🙂
