### PR TITLE
Decode html entities in the content

### DIFF
--- a/includes/webhook.php
+++ b/includes/webhook.php
@@ -93,6 +93,7 @@ function handlePublish($payload) {
     $post_type = apply_filters('storychief_change_post_type', $post_type, $story);
 
     $content = format_shortcodes($story['content']);
+    $content = decode_gutenberg_blocks_html_entities($content);
 
     $post = array(
         'post_type'    => $post_type,
@@ -171,6 +172,7 @@ function handleUpdate($payload) {
     $is_draft = apply_filters('storychief_is_draft_status', $is_test_mode, $story);
 
     $content = format_shortcodes($story['content']);
+    $content = decode_gutenberg_blocks_html_entities($content);
 
     $post = array(
         'ID'           => $story['external_id'],
@@ -303,9 +305,20 @@ function format_shortcodes($content) {
             $content = str_replace($shortcode_string, $shortcode_string_formatted, $content);
         }
     }
-    
-    // Decode html entities.
-    return wp_specialchars_decode($content, ENT_QUOTES);
+
+    return $content;
+}
+
+/**
+ * Replaces html entities that are used in gutenberg blocks.
+ */
+function decode_gutenberg_blocks_html_entities($content) {
+
+    $content = str_replace("&lt;!--", "<!--", $content);
+    $content = str_replace("--&gt;", "-->", $content);
+    $content = str_replace("&quot;", "'", $content);
+
+    return $content;
 }
 
 /**

--- a/includes/webhook.php
+++ b/includes/webhook.php
@@ -303,8 +303,9 @@ function format_shortcodes($content) {
             $content = str_replace($shortcode_string, $shortcode_string_formatted, $content);
         }
     }
-
-    return $content;
+    
+    // Decode html entities.
+    return wp_specialchars_decode($content, ENT_QUOTES);
 }
 
 /**

--- a/includes/webhook.php
+++ b/includes/webhook.php
@@ -314,9 +314,19 @@ function format_shortcodes($content) {
  */
 function decode_gutenberg_blocks_html_entities($content) {
 
-    $content = str_replace("&lt;!--", "<!--", $content);
-    $content = str_replace("--&gt;", "-->", $content);
-    $content = str_replace("&quot;", "'", $content);
+    preg_match_all('<!-- wp:(.*?)-->', $content, $matches, PREG_SET_ORDER); // Get all gutenberg blocks
+
+    if (count($matches)){
+        $content = str_replace("&lt;!--", "<!--", $content);
+        $content = str_replace("--&gt;", "-->", $content);
+        foreach ($matches as $block) {
+            $block_json = $block[0];
+            if ($block_json) {
+                $block_json_formatted = str_replace(['&quot;', '”'], '"', $block_json);
+                $content = str_replace($block_json, $block_json_formatted, $content);
+            }
+        }
+    }
 
     return $content;
 }


### PR DESCRIPTION
Decode html entities in the content to be able to render Gutenberg blocks if they exist in the content body 
[wp_specialchars_decode](https://developer.wordpress.org/reference/functions/wp_specialchars_decode/)

Ex:
In Storychief 
![Screenshot 2022-10-10 at 14 58 15](https://user-images.githubusercontent.com/48244596/194871728-f84788df-7968-47f7-8402-79e477112d70.png)

In wp
![Screenshot 2022-10-10 at 14 57 59](https://user-images.githubusercontent.com/48244596/194871759-73afc79b-ae83-4d17-9ccb-9c8139e88e1f.png)

