### PR TITLE
Feature/publish as draft [SC-798]

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -13,8 +13,8 @@ What are you changing? Why is this change being made? What problem is it solving
 
 Please include step by step instructions on how to test the PR.
 
-1. Which webhook endpoint
-2. Example of payload
+1. Which webhook endpoint (https://developers.storychief.io/)
+2. Example of payload 
 3. etc.
 
 ## Screenshots

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,22 @@
+<!--
+Before submitting the PR, make sure:
+- You have tested the code
+- You added an automated test (if applicable)
+- You added release instructions (if applicable)
+-->
+
+## Description
+
+What are you changing? Why is this change being made? What problem is it solving?
+
+## Testing Instructions
+
+Please include step by step instructions on how to test the PR.
+
+1. Which webhook endpoint
+2. Example of payload
+3. etc.
+
+## Screenshots
+
+<!-- In case UI changes were made, include some screenshots here. -->

--- a/includes/tools.php
+++ b/includes/tools.php
@@ -51,7 +51,7 @@ function isAnySeoPluginActive() {
  * @return bool
  */
 function isOpenGraphHandled() {
-    return (isYoastPluginActive() || isSeopressPluginActive());
+    return (isYoastPluginActive() || isSeopressPluginActive() || isRankMathPluginActive());
 }
 
 /**

--- a/includes/tools.php
+++ b/includes/tools.php
@@ -51,7 +51,7 @@ function isAnySeoPluginActive() {
  * @return bool
  */
 function isOpenGraphHandled() {
-    return (isYoastPluginActive() || isSeopressPluginActive() || isRankMathPluginActive());
+    return (isYoastPluginActive() || isSeopressPluginActive());
 }
 
 /**
@@ -91,7 +91,7 @@ function validMac($payload) {
  */
 function getPermalink($post_ID) {
     if(get_post_status($post_ID) !== 'publish'){
-        return null;
+        return get_preview_post_link($post_ID);
     }
 
     return get_permalink($post_ID);

--- a/includes/webhook.php
+++ b/includes/webhook.php
@@ -2,46 +2,51 @@
 
 namespace Storychief\Webhook;
 
-use WP_REST_Request;
 use WP_Error;
+use WP_REST_Request;
 
 use function Storychief\Settings\get_sc_option;
 
-function disable_cron() {
+function disable_cron()
+{
     if (isset($_SERVER['REQUEST_URI']) && strpos($_SERVER['REQUEST_URI'], '/wp-json/storychief/') !== false) {
-        if ( ! defined( 'DISABLE_WP_CRON' ) ) {
-            define( 'DISABLE_WP_CRON', true );
+        if (! defined('DISABLE_WP_CRON')) {
+            define('DISABLE_WP_CRON', true);
         }
 
         remove_action('init', 'wp_cron');
         remove_action('wp_loaded', '_wp_cron');
     }
 }
-add_action('plugins_loaded', __NAMESPACE__ . '\disable_cron', 0, 20);
+add_action('plugins_loaded', __NAMESPACE__.'\disable_cron', 0, 20);
 
-function register_routes() {
-    register_rest_route('storychief', 'webhook', array(
-        'methods'  => 'POST',
-        'callback' =>  __NAMESPACE__ . '\handle',
+function register_routes()
+{
+    register_rest_route('storychief', 'webhook', [
+        'methods' => 'POST',
+        'callback' => __NAMESPACE__.'\handle',
         'permission_callback' => '__return_true',
-    ));
+    ]);
 }
-add_action('rest_api_init', __NAMESPACE__ . '\register_routes');
-
+add_action('rest_api_init', __NAMESPACE__.'\register_routes');
 
 /**
  * The Main webhook function, orchestrates the requested event to its corresponding function.
  *
- * @param WP_REST_Request $request
  * @return mixed
  */
-function handle(WP_REST_Request $request) {
+function handle(WP_REST_Request $request)
+{
     storychief_debug_mode();
 
     $payload = json_decode($request->get_body(), true);
 
-    if (!\Storychief\Tools\validMac($payload)) return new WP_Error('invalid_mac', 'The Mac is invalid', array('status' => 400));
-    if (!isset($payload['meta']['event'])) return new WP_Error('no_event_type', 'The event is not set', array('status' => 400));
+    if (! \Storychief\Tools\validMac($payload)) {
+        return new WP_Error('invalid_mac', 'The Mac is invalid', ['status' => 400]);
+    }
+    if (! isset($payload['meta']['event'])) {
+        return new WP_Error('no_event_type', 'The event is not set', ['status' => 400]);
+    }
 
     $payload = apply_filters('storychief_before_handle_filter', $payload);
 
@@ -67,11 +72,15 @@ function handle(WP_REST_Request $request) {
             break;
     }
 
-    if (is_wp_error($response)) return $response;
+    if (is_wp_error($response)) {
+        return $response;
+    }
 
     $response = apply_filters('storychief_alter_response', $response);
 
-    if (!is_null($response)) $response  = \Storychief\Tools\appendMac($response);
+    if (! is_null($response)) {
+        $response = \Storychief\Tools\appendMac($response);
+    }
 
     return rest_ensure_response($response);
 }
@@ -79,13 +88,14 @@ function handle(WP_REST_Request $request) {
 /**
  * Handle a publish webhook call
  *
- * @param $payload
  * @return array
  *
  * @link https://developers.storychief.io/#fb73b0fc-39f6-4c2e-b231-6687a2646287
  */
-function handlePublish($payload) {
+function handlePublish($payload)
+{
     $story = $payload['data'];
+    $meta = $payload['meta'];
 
     // Before publish action
     do_action('storychief_before_publish_action', array_merge([], $story));
@@ -93,7 +103,7 @@ function handlePublish($payload) {
     $is_test_mode = (bool) get_sc_option('test_mode');
     $is_draft = $is_test_mode;
 
-    if (!$is_test_mode && isset($story['status']) && $story['status'] === 'draft') {
+    if (! $is_test_mode && isset($meta['status']) && $meta['status'] === 'draft') {
         $is_draft = true;
     }
 
@@ -106,18 +116,18 @@ function handlePublish($payload) {
     $content = format_shortcodes($story['content']);
     $content = decode_gutenberg_blocks_html_entities($content);
 
-    $post = array(
-        'post_type'    => $post_type,
-        'post_title'   => $story['title'],
+    $post = [
+        'post_type' => $post_type,
+        'post_title' => $story['title'],
         'post_content' => $content,
         'post_excerpt' => $story['excerpt'] ? $story['excerpt'] : '',
-        'post_status'  => $status,
-        'post_author'  => null,
-        'meta_input'   => array(),
-    );
+        'post_status' => $status,
+        'post_author' => null,
+        'meta_input' => [],
+    ];
 
     // Set the slug
-    if (isset($story['seo_slug']) && !empty($story['seo_slug'])) {
+    if (isset($story['seo_slug']) && ! empty($story['seo_slug'])) {
         $post['post_name'] = $story['seo_slug'];
     }
 
@@ -127,7 +137,7 @@ function handlePublish($payload) {
 
     $post_ID = safely_upsert_story($post);
 
-    $story = array_merge($story, array('external_id' => $post_ID));
+    $story = array_merge($story, ['external_id' => $post_ID]);
 
     // Author
     do_action('storychief_save_author_action', $story);
@@ -155,28 +165,30 @@ function handlePublish($payload) {
     // WPEngine (which caches outside of WP) also listens for this action.
     clean_post_cache($post_ID);
 
-    $permalink = apply_filters( 'storychief_publish_permalink', \Storychief\Tools\getPermalink($post_ID), $post_ID );
+    $permalink = apply_filters('storychief_publish_permalink', \Storychief\Tools\getPermalink($post_ID), $post_ID);
 
-    return array(
+    return [
         'id' => $post_ID,
         'permalink' => $permalink,
         'status' => $is_draft ? 'draft' : 'published',
-    );
+    ];
 }
 
 /**
  * Handle a update webhook call
  *
- * @param array $payload
+ * @param  array  $payload
  * @return array|WP_Error
  *
  * @link https://developers.storychief.io/#ef1fe8bf-6efe-41df-aa7c-f931c128ef61
  */
-function handleUpdate($payload) {
+function handleUpdate($payload)
+{
     $story = $payload['data'];
+    $meta = $payload['meta'];
 
-    if (!get_post_status($story['external_id'])) {
-        return new WP_Error('post_not_found', 'The post could not be found', array('status' => 404));
+    if (! get_post_status($story['external_id'])) {
+        return new WP_Error('post_not_found', 'The post could not be found', ['status' => 404]);
     }
 
     // Before publish action
@@ -185,7 +197,7 @@ function handleUpdate($payload) {
     $is_test_mode = (bool) get_sc_option('test_mode');
     $is_draft = $is_test_mode;
 
-    if (!$is_test_mode && isset($story['status']) && $story['status'] === 'draft') {
+    if (! $is_test_mode && isset($meta['status']) && $meta['status'] === 'draft') {
         $is_draft = true;
     }
 
@@ -195,17 +207,17 @@ function handleUpdate($payload) {
     $content = format_shortcodes($story['content']);
     $content = decode_gutenberg_blocks_html_entities($content);
 
-    $post = array(
-        'ID'           => $story['external_id'],
-        'post_title'   => $story['title'],
+    $post = [
+        'ID' => $story['external_id'],
+        'post_title' => $story['title'],
         'post_content' => $content,
         'post_excerpt' => $story['excerpt'] ? $story['excerpt'] : '',
-        'post_status'  => $status,
-        'meta_input'   => array(),
-    );
+        'post_status' => $status,
+        'meta_input' => [],
+    ];
 
     // Set the slug
-    if (isset($story['seo_slug']) && !empty($story['seo_slug'])) {
+    if (isset($story['seo_slug']) && ! empty($story['seo_slug'])) {
         $post['post_name'] = $story['seo_slug'];
     }
 
@@ -215,7 +227,7 @@ function handleUpdate($payload) {
 
     $post_ID = safely_upsert_story($post);
 
-    $story = array_merge($story, array('external_id' => $post_ID));
+    $story = array_merge($story, ['external_id' => $post_ID]);
 
     // Author
     do_action('storychief_save_author_action', $story);
@@ -243,41 +255,42 @@ function handleUpdate($payload) {
     // WPEngine (which caches outside of WP) also listens for this action.
     clean_post_cache($post_ID);
 
-    $permalink = apply_filters( 'storychief_publish_permalink', \Storychief\Tools\getPermalink($post_ID), $post_ID );
+    $permalink = apply_filters('storychief_publish_permalink', \Storychief\Tools\getPermalink($post_ID), $post_ID);
 
-    return array(
+    return [
         'id' => $post_ID,
         'permalink' => $permalink,
         'status' => $is_draft ? 'draft' : 'published',
-    );
+    ];
 }
 
 /**
  * Handle a delete webhook call
  *
- * @param $payload
  * @return array
  */
-function handleDelete($payload) {
+function handleDelete($payload)
+{
     $story = $payload['data'];
     $post_ID = $story['external_id'];
     wp_delete_post($post_ID);
 
     do_action('storychief_after_delete_action', $story);
 
-    return array(
-        'id'        => $story['external_id'],
+    return [
+        'id' => $story['external_id'],
         'permalink' => null,
-    );
+    ];
 }
 
 /**
  * Handle a connection test webhook call.
  *
- * @param array $payload
+ * @param  array  $payload
  * @return array
  */
-function handleConnectionCheck($payload) {
+function handleConnectionCheck($payload)
+{
     $story = $payload['data'];
 
     do_action('storychief_after_test_action', $story);
@@ -350,21 +363,22 @@ function handleConnectionCheck($payload) {
  *
  * @return mixed
  */
-function missingMethod() {
-    return;
+function missingMethod()
+{
+
 }
 
 /**
  * Safely save a story by disabling & re-enabling sanitation.
  *
- * @param $data
  * @return int
  */
-function safely_upsert_story ($data) {
+function safely_upsert_story($data)
+{
     // disable sanitation
     kses_remove_filters();
 
-    if(isset($data['ID'])) {
+    if (isset($data['ID'])) {
         $post_ID = wp_update_post($data);
     } else {
         $post_ID = wp_insert_post($data);
@@ -376,9 +390,10 @@ function safely_upsert_story ($data) {
     return $post_ID;
 }
 
-function format_shortcodes($content) {
+function format_shortcodes($content)
+{
 
-    preg_match_all('/' . get_shortcode_regex() . '/', $content, $matches, PREG_SET_ORDER);
+    preg_match_all('/'.get_shortcode_regex().'/', $content, $matches, PREG_SET_ORDER);
 
     foreach ($matches as $shortcode) {
         $shortcode_string = $shortcode[0];
@@ -394,13 +409,14 @@ function format_shortcodes($content) {
 /**
  * Replaces html entities that are used in gutenberg blocks.
  */
-function decode_gutenberg_blocks_html_entities($content) {
+function decode_gutenberg_blocks_html_entities($content)
+{
 
     preg_match_all('<!-- wp:(.*?)-->', $content, $matches, PREG_SET_ORDER); // Get all gutenberg blocks
 
-    if (count($matches)){
-        $content = str_replace("&lt;!--", "<!--", $content);
-        $content = str_replace("--&gt;", "-->", $content);
+    if (count($matches)) {
+        $content = str_replace('&lt;!--', '<!--', $content);
+        $content = str_replace('--&gt;', '-->', $content);
         foreach ($matches as $block) {
             $block_json = $block[0];
             if ($block_json) {
@@ -433,7 +449,7 @@ function storychief_debug_mode()
         ini_set('log_errors', 1);
 
         // Sets a log file path you can access in the theme editor.
-        $log_path = STORYCHIEF_DIR . DIRECTORY_SEPARATOR . 'error.log';
+        $log_path = STORYCHIEF_DIR.DIRECTORY_SEPARATOR.'error.log';
         ini_set('error_log', $log_path);
     }
 }

--- a/includes/webhook.php
+++ b/includes/webhook.php
@@ -81,6 +81,8 @@ function handle(WP_REST_Request $request) {
  *
  * @param $payload
  * @return array
+ *
+ * @link https://developers.storychief.io/#fb73b0fc-39f6-4c2e-b231-6687a2646287
  */
 function handlePublish($payload) {
     $story = $payload['data'];
@@ -89,11 +91,13 @@ function handlePublish($payload) {
     do_action('storychief_before_publish_action', array_merge([], $story));
 
     $is_test_mode = (bool) get_sc_option('test_mode');
-    $is_draft = apply_filters('storychief_is_draft_status', $is_test_mode, $story);
+    $is_draft = $is_test_mode;
 
-    if (isset($story['status']) && $story['status'] === 'draft') {
+    if (!$is_test_mode && isset($story['status']) && $story['status'] === 'draft') {
         $is_draft = true;
     }
+
+    $is_draft = apply_filters('storychief_is_draft_status', $is_draft, $story);
 
     $status = $is_draft ? 'draft' : 'publish';
     $post_type = get_sc_option('post_type') ? get_sc_option('post_type') : 'post';
@@ -156,7 +160,7 @@ function handlePublish($payload) {
     return array(
         'id' => $post_ID,
         'permalink' => $permalink,
-        'status' => $status === 'draft' ? 'draft' : 'published',
+        'status' => $is_draft ? 'draft' : 'published',
     );
 }
 
@@ -165,6 +169,8 @@ function handlePublish($payload) {
  *
  * @param array $payload
  * @return array|WP_Error
+ *
+ * @link https://developers.storychief.io/#ef1fe8bf-6efe-41df-aa7c-f931c128ef61
  */
 function handleUpdate($payload) {
     $story = $payload['data'];
@@ -177,11 +183,13 @@ function handleUpdate($payload) {
     do_action('storychief_before_publish_action', array_merge([], $story));
 
     $is_test_mode = (bool) get_sc_option('test_mode');
-    $is_draft = apply_filters('storychief_is_draft_status', $is_test_mode, $story);
+    $is_draft = $is_test_mode;
 
-    if (isset($story['status']) && $story['status'] === 'draft') {
+    if (!$is_test_mode && isset($story['status']) && $story['status'] === 'draft') {
         $is_draft = true;
     }
+
+    $is_draft = apply_filters('storychief_is_draft_status', $is_draft, $story);
 
     $status = $is_draft ? 'draft' : 'publish';
     $content = format_shortcodes($story['content']);
@@ -240,7 +248,7 @@ function handleUpdate($payload) {
     return array(
         'id' => $post_ID,
         'permalink' => $permalink,
-        'status' => $status === 'draft' ? 'draft' : 'published',
+        'status' => $is_draft ? 'draft' : 'published',
     );
 }
 

--- a/includes/webhook.php
+++ b/includes/webhook.php
@@ -286,8 +286,20 @@ function handleConnectionCheck($payload) {
     return [
         'meta' => [
             'plugin_version' => STORYCHIEF_VERSION,
-            'cms_type' => 'wordpress',
-            'cms_version' => get_bloginfo('version'),
+            'versioning' => [
+                [
+                    'type' => 'php_version',
+                    'value' => phpversion(),
+                ],
+                [
+                    'type' => 'cms_type',
+                    'value' => 'wordpress',
+                ],
+                [
+                    'type' => 'cms_version',
+                    'value' => get_bloginfo('version'),
+                ],
+            ],
             'features' => [
                 'publish_as_draft',
             ],
@@ -328,11 +340,10 @@ function handleConnectionCheck($payload) {
                     'description' => 'All images inside an article will be downloaded.',
                     'value' => (bool) get_sc_option('sideload_images'),
                 ],
-            ]
-        ]
+            ],
+        ],
     ];
 }
-
 
 /**
  * Handle calls to missing methods on the controller.

--- a/readme.txt
+++ b/readme.txt
@@ -2,10 +2,10 @@
 Contributors: StoryChief
 Donate link: https://storychief.io
 Tags: Content marketing calendar, social media scheduling, content marketing, schedule facebook posts, schedule to twitter, schedule posts to Linkedin, social media analytics
-Requires at least: 4.6
+Requires at least: 5.2
 Tested up to: 6.4
-Requires PHP: 5.4
-Stable tag: 1.0.38
+Requires PHP: 7.0
+Stable tag: 1.0.39
 License: GPLv3 or later
 License URI: https://www.gnu.org/licenses/gpl-3.0.html
 
@@ -48,7 +48,8 @@ This plugin:
 
 * This plugin requires a [StoryChief](https://storychief.io) account.
 	* Not a StoryChief user yet? [Sign up for free!](https://app.storychief.io/register)
-* PHP version 5.4 or higher
+* PHP version 7.0 or higher
+* WordPress version 5.2 or higher
 
 === Actions and filters ===
 
@@ -98,6 +99,12 @@ Support for [WPBakery](https://help.storychief.io/en/articles/2111311-wordpress-
 10.  Measure Quality
 
 == Changelog ==
+
+= 1.0.39 =
+* Added: Connection check now returns meta-data; detect the feature to publish an article as draft
+* Added: Future feature "published as draft" in StoryChief
+* Deprecation: Dropped support for PHP below 7.0
+* Deprecation: Dropped support for WordPress below 5.2
 
 = 1.0.38 =
 * Improvement: Tested up to WordPress 6.4

--- a/storychief.php
+++ b/storychief.php
@@ -4,11 +4,14 @@
  * Plugin Name: StoryChief
  * Plugin URI: http://storychief.io/wordpress
  * Description: Publish your blog posts from StoryChief to WordPress.
- * Version: 1.0.38
+ * Version: 1.0.39
+ * Requires at least: 5.2
+ * Requires PHP: 7.0
  * Author: StoryChief
  * Text Domain: storychief
  * Author URI: http://storychief.io
- * License: GPL2
+ * License: GPLv3 or later
+ * License URI: https://www.gnu.org/licenses/gpl-3.0.html
  */
 
 namespace Storychief;
@@ -19,7 +22,7 @@ if (!function_exists('add_action')) {
 	exit;
 }
 
-define('STORYCHIEF_VERSION', '1.0.38');
+define('STORYCHIEF_VERSION', '1.0.39');
 if (!defined('STORYCHIEF_DIR')) {
 	define('STORYCHIEF_DIR', __DIR__);
 }


### PR DESCRIPTION
<!--
Before submitting the PR, make sure:
- You have tested the code
- You added an automated test (if applicable)
- You added release instructions (if applicable)
-->

## Description

Introduce a feature that allows users to publish articles in draft form, enabling them to transfer content from StoryChief to WordPress without it being accessible to the public.

- People can publish as draft directly from StoryChief
- People can preview articles before actually publishing

https://developers.storychief.io/

### Connection check

The connection test will now provide meta-data as well, which can be utilized for troubleshooting.

```json
{
    "meta": {
        "plugin_version": "1.0.39",
        "versioning": [
            {
                "type": "php_version",
                "value": "8.2.16"
            },
            {
                "type": "cms_type",
                "value": "wordpress"
            },
            {
                "type": "cms_version",
                "value": "6.4.3"
            }
        ],
        "features": [
            "publish_as_draft"
        ],
        "settings": [
            {
                "key": "test_mode",
                "title": "Testing mode",
                "description": "Keep your articles as draft.",
                "value": false
            }
        ]
   }
}
```

It also contains an attribute (`features`) to detect if _publishing as draft_ is supported or not.

```json
{
    "meta": {
      "features": [
            "publish_as_draft"
      ],
    }
}
```

### Publishing or updating to WordPress

A new property `status` has been added, to save an article as draft or publish directly.

```json
{
    "data": {
        "external_id": null,
        "storychief_id": 1
   },
   "meta": {
        "status": "draft"
   }
}
```

| value | description |
| --- | --- | 
| `draft` | Published as draft and will return a preview link |
| `publish` or _any other value_ | Published and returns a public page | 

### As draft 

When you publish as draft, the response will return a preview permalink.

```json
{
    "data": {
        "id": 1,
        "permalink": "http://dev.wordpress.com/nl/?p=1&preview=true",
        "mac": "xyz"
    },
   "meta": {
        "status": "draft"
   }
}
```
### Published 

```json
{
    "data": {
        "id": 1,
        "permalink": "http://dev.wordpress.com/nl/sloths-are-awesome",
        "mac": "xyz"
    },
   "meta": {
        "status": "published"
   }
}
```


### Plugin

I updated the minimal requirements  and some of the plugin information.

- Dropped PHP support below 7.0
- Dropped WordPress support below 5.2 
  - WordPress itself dropped support below PHP 7.0 in 5.2
- Mention the correct license
- Add a link to the correct license

## Testing Instructions

Please use this PostMan collection.

https://developers.storychief.io/

#### Connection check 

WordPress returns the attribute `meta.features` and `meta.settings`.

#### Publish or update

When you use the **publish** and **update** endpoint, you can use the property `status`. To can force an article to become published or drafted.


> [!IMPORTANT]
> The setting debug mode or the filter `storychief_is_draft_status` takes priority above the attribute `status` inside the payload.
> 
> ![image](https://github.com/Story-Chief/wordpress/assets/4041473/7d424963-bd09-4ae5-b55d-3e280c7c0114)
