### PR TITLE
Add support to lock updates, only change the status to published.

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -5,7 +5,7 @@ Tags: Content calendar, Social media scheduling, Content marketing, Analytics
 Requires at least: 5.2
 Tested up to: 6.5
 Requires PHP: 7.0
-Stable tag: 1.0.40
+Stable tag: 1.0.41
 License: GPLv3 or later
 License URI: https://www.gnu.org/licenses/gpl-3.0.html
 
@@ -92,6 +92,9 @@ Support for [WPBakery](https://help.storychief.io/en/articles/2111311-wordpress-
 6.  Ambassadors
 
 == Changelog ==
+
+= 1.0.41 =
+* Add support to lock updates to content, only update status to published
 
 = 1.0.40 =
 * Updated readme

--- a/storychief.php
+++ b/storychief.php
@@ -4,7 +4,7 @@
  * Plugin Name: StoryChief
  * Plugin URI: http://storychief.io/wordpress
  * Description: Publish your blog posts from StoryChief to WordPress.
- * Version: 1.0.40
+ * Version: 1.0.41
  * Requires at least: 5.2
  * Requires PHP: 7.0
  * Author: StoryChief
@@ -22,7 +22,7 @@ if (!function_exists('add_action')) {
 	exit;
 }
 
-define('STORYCHIEF_VERSION', '1.0.40');
+define('STORYCHIEF_VERSION', '1.0.41');
 if (!defined('STORYCHIEF_DIR')) {
 	define('STORYCHIEF_DIR', __DIR__);
 }


### PR DESCRIPTION

<!--
Before submitting the PR, make sure:
- You have tested the code
- You added an automated test (if applicable)
- You added release instructions (if applicable)
-->

## Description

Add the ability in StoryChief to lock content updates.

1. Customer will write the copy 
2. Once approved internally schedule it for publishing
3. The customer will add lay-out changes; adding interactive blocks, ... 

Was requested by some customers that want to push the copy and afterward change the lay-out (add widgets, blocks).

## Testing Instructions

N/A
